### PR TITLE
new feature: add batch request support: #5.

### DIFF
--- a/jsonrpc_async/jsonrpc.py
+++ b/jsonrpc_async/jsonrpc.py
@@ -80,7 +80,8 @@ class Server(jsonrpc_base.Server):
                 for _id, resp in r_data.items()}
 
     def __getattr__(self, method_name):
-        if method_name.startswith("_"):  # prevent rpc-calls for private methods
+        if method_name.startswith("_"):  # prevent rpc-calls for private
+                                         # methods
             raise AttributeError("invalid attribute '%s'" % method_name)
         return Method(self, self.__register, method_name)
 
@@ -96,7 +97,8 @@ class Method(BaseMethod):
         return self._server.send_message(self.raw(*args, **kwargs))
 
     def __getattr__(self, method_name):
-        if method_name.startswith("_"):  # prevent rpc-calls for private methods
+        if method_name.startswith("_"):  # prevent rpc-calls for private
+                                         # methods
             raise AttributeError("invalid attribute '%s'" % method_name)
         return Method(self._server, self.__register_method,
                       "%s.%s" % (self.__method_name, method_name))
@@ -111,10 +113,12 @@ class Method(BaseMethod):
             msg_id = random.randint(1, sys.maxsize)
 
         if args and kwargs:
-            raise ProtocolError('JSON-RPC spec forbids mixing arguments and keyword arguments')
+            raise ProtocolError('JSON-RPC spec forbids mixing arguments and'
+                                ' keyword arguments')
 
         # from the specs:
-        # "If resent, parameters for the rpc call MUST be provided as a Structured value.
+        # "If resent, parameters for the rpc call MUST be provided as a
+        # Structured value.
         #  Either by-position through an Array or by-name through an Object."
         if len(args) == 1 and isinstance(args[0], collections.abc.Mapping):
             args = dict(args[0])

--- a/jsonrpc_async/jsonrpc.py
+++ b/jsonrpc_async/jsonrpc.py
@@ -1,9 +1,15 @@
 import asyncio
+import collections
 import functools
+import json
+import random
+import sys
 
 import aiohttp
 import jsonrpc_base
 from jsonrpc_base import TransportError
+from jsonrpc_base.jsonrpc import ProtocolError
+from jsonrpc_base.jsonrpc import Method as BaseMethod, Request as BaseRequest
 
 
 class Server(jsonrpc_base.Server):
@@ -49,3 +55,86 @@ class Server(jsonrpc_base.Server):
                 'Cannot deserialize response body', message, value_error)
 
         return message.parse_response(response_data)
+
+    async def batch_message(self, **kw):
+        # we assume no notifications in the batch
+        batch = [m.as_json_obj() for m in kw.values()]
+        id_msg = {m['id']: k for k, m in kw.items()}
+
+        try:
+            response = await self._request(data=json.dumps(batch))
+        except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
+            raise TransportError('Transport Error', "batch", exc)
+
+        if response.status != 200:
+            raise TransportError(
+                    'HTTP %d %s' % (response.status, response.reason), "batch")
+
+        try:
+            response_data = await response.json(**self._json_args)
+        except ValueError as value_error:
+            raise TransportError(
+                    'Cannot deserialize response body', "batch", value_error)
+        r_data = {resp['id']: resp for resp in response_data}
+        return {id_msg[_id]: kw[id_msg[_id]].parse_response(resp)
+                for _id, resp in r_data.items()}
+
+    def __getattr__(self, method_name):
+        if method_name.startswith("_"):  # prevent rpc-calls for private methods
+            raise AttributeError("invalid attribute '%s'" % method_name)
+        return Method(self, self.__register, method_name)
+
+
+class Method(BaseMethod):
+    """Map the methods called on the server to json-rpc methods."""
+    def __init__(self, server, register_method, method_name):
+        self._server = server
+        self.__register_method = register_method
+        self.__method_name = method_name
+
+    def __call__(self, *args, **kwargs):
+        return self._server.send_message(self.raw(*args, **kwargs))
+
+    def __getattr__(self, method_name):
+        if method_name.startswith("_"):  # prevent rpc-calls for private methods
+            raise AttributeError("invalid attribute '%s'" % method_name)
+        return Method(self._server, self.__register_method,
+                      "%s.%s" % (self.__method_name, method_name))
+
+    def raw(self, *args, **kwargs):
+        method_name = self.__method_name
+        if kwargs.pop('_notification', False):
+            msg_id = None
+        else:
+            # some JSON-RPC servers complain when receiving str(uuid.uuid4()).
+            # Let's pick something simpler.
+            msg_id = random.randint(1, sys.maxsize)
+
+        if args and kwargs:
+            raise ProtocolError('JSON-RPC spec forbids mixing arguments and keyword arguments')
+
+        # from the specs:
+        # "If resent, parameters for the rpc call MUST be provided as a Structured value.
+        #  Either by-position through an Array or by-name through an Object."
+        if len(args) == 1 and isinstance(args[0], collections.abc.Mapping):
+            args = dict(args[0])
+
+        return Request(method_name, args or kwargs, msg_id)
+
+
+class Request(BaseRequest):
+    def as_json_obj(self):
+        """Generate the raw JSON message to be sent to the server"""
+        data = {'jsonrpc': '2.0', 'method': self.method}
+        if self.params is not None:
+            data['params'] = self.params
+        if self.msg_id is not None:
+            data['id'] = self.msg_id
+        return data
+
+    def __getitem__(self, item):
+        return self.as_json_obj()[item]
+
+    def serialize(self):
+        """Generate the raw JSON message to be sent to the server"""
+        return json.dumps(self.as_json_obj())

--- a/jsonrpc_async/jsonrpc.py
+++ b/jsonrpc_async/jsonrpc.py
@@ -67,21 +67,20 @@ class Server(jsonrpc_base.Server):
             raise TransportError('Transport Error', "batch", exc)
 
         if response.status != 200:
-            raise TransportError(
-                    'HTTP %d %s' % (response.status, response.reason), "batch")
+            raise TransportError('HTTP %d %s' % (response.status,
+                                                 response.reason), "batch")
 
         try:
             response_data = await response.json(**self._json_args)
         except ValueError as value_error:
-            raise TransportError(
-                    'Cannot deserialize response body', "batch", value_error)
+            raise TransportError('Cannot deserialize response body', "batch",
+                                 value_error)
         r_data = {resp['id']: resp for resp in response_data}
         return {id_msg[_id]: kw[id_msg[_id]].parse_response(resp)
                 for _id, resp in r_data.items()}
 
     def __getattr__(self, method_name):
-        if method_name.startswith("_"):  # prevent rpc-calls for private
-                                         # methods
+        if method_name.startswith("_"):  # prevent rpc-calls for private methods
             raise AttributeError("invalid attribute '%s'" % method_name)
         return Method(self, self.__register, method_name)
 
@@ -97,8 +96,7 @@ class Method(BaseMethod):
         return self._server.send_message(self.raw(*args, **kwargs))
 
     def __getattr__(self, method_name):
-        if method_name.startswith("_"):  # prevent rpc-calls for private
-                                         # methods
+        if method_name.startswith("_"):  # prevent rpc-calls for private methods
             raise AttributeError("invalid attribute '%s'" % method_name)
         return Method(self._server, self.__register_method,
                       "%s.%s" % (self.__method_name, method_name))

--- a/jsonrpc_async/jsonrpc.py
+++ b/jsonrpc_async/jsonrpc.py
@@ -64,16 +64,16 @@ class Server(jsonrpc_base.Server):
         try:
             response = await self._request(data=json.dumps(batch))
         except (aiohttp.ClientError, asyncio.TimeoutError) as exc:
-            raise TransportError('Transport Error', "batch", exc)
+            raise TransportError('Transport Error', None, exc)
 
         if response.status != 200:
             raise TransportError('HTTP %d %s' % (response.status,
-                                                 response.reason), "batch")
+                                                 response.reason), None)
 
         try:
             response_data = await response.json(**self._json_args)
         except ValueError as value_error:
-            raise TransportError('Cannot deserialize response body', "batch",
+            raise TransportError('Cannot deserialize response body', None,
                                  value_error)
         r_data = {resp['id']: resp for resp in response_data}
         return {id_msg[_id]: kw[id_msg[_id]].parse_response(resp)

--- a/tests.py
+++ b/tests.py
@@ -7,7 +7,6 @@ import aiohttp
 import aiohttp.web
 import aiohttp.test_utils
 
-import jsonrpc_base
 from jsonrpc_async import Server, ProtocolError, TransportError
 from jsonrpc_async.jsonrpc import Request
 
@@ -309,7 +308,8 @@ async def test_batch_requests(test_client):
         id2 = request_message[1]['id']
         return aiohttp.web.Response(
                 text='[{"jsonrpc": "2.0", "result": 11, "id": %d},'
-                     '{"jsonrpc": "2.0", "result": 22, "id": %d}]'%(id1, id2),
+                     '{"jsonrpc": "2.0", "result": 22, "id": %d}]' % (id1,
+                                                                      id2),
                 content_type='application/json')
 
     def create_app(loop):
@@ -324,4 +324,3 @@ async def test_batch_requests(test_client):
                 two=server.dos.raw())
     assert x['one'] == 11
     assert x['two'] == 22
-

--- a/tests.py
+++ b/tests.py
@@ -306,11 +306,10 @@ async def test_batch_requests(test_client):
         request_message = await request.json()
         id1 = request_message[0]['id']
         id2 = request_message[1]['id']
-        return aiohttp.web.Response(
-                text='[{"jsonrpc": "2.0", "result": 11, "id": %d},'
-                     '{"jsonrpc": "2.0", "result": 22, "id": %d}]' % (id1,
-                                                                      id2),
-                content_type='application/json')
+        return aiohttp.web.Response(text='[{"jsonrpc": "2.0", "result": 11, '
+                                         '"id": %d},{"jsonrpc": "2.0", "result'
+                                         '": 22, "id": %d}]' % (id1, id2),
+                                    content_type='application/json')
 
     def create_app(loop):
         app = aiohttp.web.Application(loop=loop)
@@ -319,8 +318,6 @@ async def test_batch_requests(test_client):
 
     client = await test_client(create_app)
     server = Server('/', client)
-    x = await server.batch_message(
-                one=server.uno.raw(),
-                two=server.dos.raw())
+    x = await server.batch_message(one=server.uno.raw(), two=server.dos.raw())
     assert x['one'] == 11
     assert x['two'] == 22


### PR DESCRIPTION
Here is a simple implementation to support batch requests this way:

```python
    server = Server('/', client)
    x = await server.batch_message(
                one=server.uno.raw(),
                two=server.dos.raw(arg="something"))
```