### PR TITLE
Fix tests with later pytest-aiohttp

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: [3.7, 3.8, 3.9, "3.10"]
 
     steps:
     - uses: actions/checkout@v2

--- a/README.rst
+++ b/README.rst
@@ -13,7 +13,6 @@ This is a compact and simple JSON-RPC client implementation for asyncio python c
 Main Features
 -------------
 
-* Python 3.6, 3.7, 3.8 & 3.9 compatible
 * Supports nested namespaces (eg. `app.users.getUsers()`)
 * 100% test coverage
 

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,8 +1,8 @@
-flake8==3.7.8
-coverage==5.5
-coveralls==3.0.1
+flake8>=3.7.8
+coverage>=5.5
+coveralls>=3.0.1
 jsonrpc-base>=2.1.0
 aiohttp>=3.0.0
 pytest-aiohttp>=1.0.0
-pytest==6.2.2
-pytest-cov==2.11.1
+pytest>=6.2.2
+pytest-cov>=2.11.1

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,6 +3,6 @@ coverage==5.5
 coveralls==3.0.1
 jsonrpc-base>=2.1.0
 aiohttp>=3.0.0
-pytest-aiohttp==0.3.0
+pytest-aiohttp>=1.0.0
 pytest==6.2.2
 pytest-cov==2.11.1

--- a/setup.py
+++ b/setup.py
@@ -28,10 +28,10 @@ setup(
         'Topic :: Software Development :: Libraries',
         'License :: OSI Approved :: BSD License',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
+        'Programming Language :: Python :: 3.10',
     ],
 
 )

--- a/tests.py
+++ b/tests.py
@@ -12,7 +12,8 @@ from jsonrpc_async import Server, ProtocolError, TransportError
 
 
 async def test_send_message_timeout(aiohttp_client):
-    # catch timeout responses
+    """Test the catching of the timeout responses."""
+
     async def handler(request):
         try:
             await asyncio.sleep(10)
@@ -37,6 +38,7 @@ async def test_send_message_timeout(aiohttp_client):
 
 
 async def test_send_message(aiohttp_client):
+    """Test the sending of messages."""
     # catch non-json responses
     async def handler1(request):
         return aiohttp.web.Response(
@@ -119,7 +121,7 @@ async def test_exception_passthrough(aiohttp_client):
 
 
 async def test_forbid_private_methods(aiohttp_client):
-    """Test that we can't call private methods (those starting with '_')"""
+    """Test that we can't call private methods (those starting with '_')."""
     def create_app():
         app = aiohttp.web.Application()
         return app
@@ -136,7 +138,7 @@ async def test_forbid_private_methods(aiohttp_client):
 
 
 async def test_headers_passthrough(aiohttp_client):
-    """Test that we correctly send RFC headers and merge them with users"""
+    """Test that we correctly send RFC headers and merge them with users."""
     async def handler(request):
         return aiohttp.web.Response(
             text='{"jsonrpc": "2.0", "result": true, "id": 1}',
@@ -169,7 +171,7 @@ async def test_headers_passthrough(aiohttp_client):
 
 
 async def test_method_call(aiohttp_client):
-    """mixing *args and **kwargs is forbidden by the spec"""
+    """Mixing *args and **kwargs is forbidden by the spec."""
     def create_app():
         app = aiohttp.web.Application()
         return app
@@ -184,7 +186,7 @@ async def test_method_call(aiohttp_client):
 
 
 async def test_method_nesting(aiohttp_client):
-    """Test that we correctly nest namespaces"""
+    """Test that we correctly nest namespaces."""
     async def handler(request):
         request_message = await request.json()
         if (request_message["params"][0] == request_message["method"]):
@@ -210,7 +212,7 @@ async def test_method_nesting(aiohttp_client):
 
 
 async def test_calls(aiohttp_client):
-    # rpc call with positional parameters:
+    """Test RPC call with positional parameters."""
     async def handler1(request):
         request_message = await request.json()
         assert request_message["params"] == [42, 23]
@@ -264,7 +266,7 @@ async def test_calls(aiohttp_client):
 
 
 async def test_notification(aiohttp_client):
-    # Verify that we ignore the server response
+    """Verify that we ignore the server response."""
     async def handler(request):
         return aiohttp.web.Response(
             text='{"jsonrpc": "2.0", "result": 19, "id": 1}',
@@ -282,7 +284,7 @@ async def test_notification(aiohttp_client):
 
 
 async def test_custom_loads(aiohttp_client):
-    # rpc call with positional parameters:
+    """Test RPC call with custom load."""
     loads_mock = mock.Mock(wraps=json.loads)
 
     async def handler(request):

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
 envlist = 
-    py36,
     py37,
     py38,
     py39,
+    py310,
     flake8,
 
 [testenv]
@@ -14,16 +14,6 @@ commands =
     coverage report
 deps =
     -r{toxinidir}/requirements-test.txt
-
-[testenv:py35]
-basepython = python3.5
-deps =
-	{[testenv]deps}
-
-[testenv:py36]
-basepython = python3.6
-deps =
-	{[testenv]deps}
 
 [testenv:py37]
 basepython = python3.7
@@ -37,6 +27,11 @@ deps =
 
 [testenv:py39]
 basepython = python3.9
+deps =
+	{[testenv]deps}
+
+[testenv:py310]
+basepython = python3.10
 deps =
 	{[testenv]deps}
 


### PR DESCRIPTION
For distribution packages it's problematic if requirements are pinned. Later `pytest-aiohttp` releases introduced changes which seem to break the tests of `jsonrpc-async`. Thus, it's no longer possible to build `jsonrpc-async` as the tests are failing. It affects at least nixpkgs but I guess that there are others as well.

```bash
============================= test session starts ==============================
platform linux -- Python 3.10.4, pytest-7.1.1, pluggy-1.0.0
rootdir: /build/source
plugins: aiohttp-1.0.4, asyncio-0.18.3
asyncio: mode=auto
collected 10 items                                                             

tests.py EEEEEEEEEE                                                      [100%]

==================================== ERRORS ====================================
_________________ ERROR at setup of test_send_message_timeout __________________
file /build/source/tests.py, line 14
  async def test_send_message_timeout(test_client):
      # catch timeout responses
      async def handler(request):
          try:
              await asyncio.sleep(10)
          except asyncio.CancelledError:
              # Event loop will be terminated before sleep finishes
              pass
          return aiohttp.web.Response(text='{}', content_type='application/json')

      def create_app(loop):
E       fixture 'test_client' not found
>       available fixtures: aiohttp_client, aiohttp_client_cls, aiohttp_raw_server, aiohttp_server, aiohttp_unused_port, cache, capfd, capfdbinary, caplog, capsys, capsysbinary, doctest_namespace, event_loop, loop, monkeypatch, proactor_loop, pytestconfig, record_property, record_testsuite_property, record_xml_attribute, recwarn, tmp_path, tmp_path_factory, tmpdir, tmpdir_factory, unused_tcp_port, unused_tcp_port_factory, unused_udp_port, unused_udp_port_factory
>       use 'pytest --fixtures [testpath]' for help on them.

/build/source/tests.py:14
```