### PR TITLE
Add support for async-with

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
         flake8 jsonrpc_async tests.py
     - name: Test with pytest
       run: |
-        pytest --cov-report term-missing --cov=jsonrpc_async tests.py
+        pytest --cov-report term-missing --cov=jsonrpc_async --asyncio-mode=auto tests.py
     - name: Coveralls
       uses: AndreMiras/coveralls-python-action@develop
       with:

--- a/README.rst
+++ b/README.rst
@@ -28,14 +28,11 @@ Execute remote JSON-RPC functions
     from jsonrpc_async import Server
 
     async def routine():
-        server = Server('http://localhost:8080')
-        try:
+        async with Server('http://localhost:8080') as server:
             await server.foo(1, 2)
             await server.foo(bar=1, baz=2)
             await server.foo({'foo': 'bar'})
             await server.foo.bar(baz=1, qux=2)
-        finally:
-            await server.session.close()
 
     asyncio.get_event_loop().run_until_complete(routine())
 
@@ -47,11 +44,8 @@ A notification
     from jsonrpc_async import Server
 
     async def routine():
-        server = Server('http://localhost:8080')
-        try:
+        async with Server('http://localhost:8080') as server:
             await server.foo(bar=1, _notification=True)
-        finally:
-            await server.session.close()
 
     asyncio.get_event_loop().run_until_complete(routine())
 
@@ -64,14 +58,12 @@ Pass through arguments to aiohttp (see also `aiohttp  documentation <http://aioh
     from jsonrpc_async import Server
 
     async def routine():
-        server = Server(
+        async with Server(
             'http://localhost:8080',
             auth=aiohttp.BasicAuth('user', 'pass'),
-            headers={'x-test2': 'true'})
-        try:
+            headers={'x-test2': 'true'}
+        ) as server:
             await server.foo()
-        finally:
-            await server.session.close()
 
     asyncio.get_event_loop().run_until_complete(routine())
 
@@ -84,13 +76,11 @@ Pass through aiohttp exceptions
     from jsonrpc_async import Server
 
     async def routine():
-        server = Server('http://unknown-host')
-        try:
-            await server.foo()
-        except TransportError as transport_error:
-            print(transport_error.args[1]) # this will hold a aiohttp exception instance
-        finally:
-            await server.session.close()
+        async with Server('http://unknown-host') as server:
+            try:
+                await server.foo()
+            except TransportError as transport_error:
+                print(transport_error.args[1]) # this will hold a aiohttp exception instance
 
     asyncio.get_event_loop().run_until_complete(routine())
 

--- a/jsonrpc_async/jsonrpc.py
+++ b/jsonrpc_async/jsonrpc.py
@@ -49,3 +49,10 @@ class Server(jsonrpc_base.Server):
                 'Cannot deserialize response body', message, value_error)
 
         return message.parse_response(response_data)
+
+    async def __aenter__(self):
+        await self.session.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return await self.session.__aexit__(exc_type, exc, tb)

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,7 @@ envlist =
 setenv =
     PYTHONPATH = {toxinidir}:{toxinidir}/jsonrpc_async
 commands = 
-    pytest --cov=jsonrpc_async tests.py
+    pytest --cov=jsonrpc_async --asyncio-mode=auto tests.py
     coverage report
 deps =
     -r{toxinidir}/requirements-test.txt


### PR DESCRIPTION
Hi, thanks for a great library.

This PR adds support for using `async with` context manager to close ClientSession.

The `--asyncio-mode=auto` changes is somewhat unrelated to this, but it should also fix the issue with the failing coverage and tests in Github Actions.